### PR TITLE
refactor tests and add mock tests for REST Calls

### DIFF
--- a/src/main_test.go
+++ b/src/main_test.go
@@ -94,6 +94,10 @@ func makeRESTCall(h *handlers, messages []Message) (string, error) {
 	return originalMakeRESTCall(h, messages)
 }
 
+func teardown() {
+	mockRESTCallFunc = nil
+}
+
 // mockTokenCredential implements azcore.TokenCredential for testing purposes
 type mockTokenCredential struct {
 	token azcore.AccessToken
@@ -106,6 +110,7 @@ func (m *mockTokenCredential) GetToken(ctx context.Context, opts policy.TokenReq
 
 // TestMakeRESTCall_Success tests the makeRESTCall function for a successful REST API call
 func TestMakeRESTCall_Success(t *testing.T) {
+	defer teardown()
 	// Setup mock HTTP server
 	mockResponse := `{"choices":[{"message":{"content":"Hello, how can I help you?"}}]}`
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -144,8 +149,9 @@ func TestMakeRESTCall_Success(t *testing.T) {
 	}
 }
 
-// TestMakeRESTCall_InvalidURL tests the makeRESTCall function for an invalid URL
-func TestMakeRESTCall_InvalidJSONResponse(t *testing.T) {
+// TestMakeRESTCall_ReturnsInvalidJSON tests the makeRESTCall function for returning an invalid JSON response
+func TestMakeRESTCall_ReturnsInvalidJSON(t *testing.T) {
+	defer teardown()
 	// Setup mock HTTP server to return invalid JSON
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
@@ -182,6 +188,7 @@ func TestMakeRESTCall_InvalidJSONResponse(t *testing.T) {
 
 // TestMakeRESTCall_TokenError tests the makeRESTCall function for token retrieval errors
 func TestMakeRESTCall_TokenError(t *testing.T) {
+	defer teardown()
 	h := &handlers{
 		config: &Config{
 			ModelDeploymentURL: "http://example.com",

--- a/src/main_test.go
+++ b/src/main_test.go
@@ -1,17 +1,23 @@
 package main
 
 import (
+	"context"
+	"fmt"
 	"html/template"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 )
 
 func setupTestHandlers() *handlers {
 	config := &Config{
-		AzureOpenAIKey:     "test-key",
 		ModelDeploymentURL: "test-url",
-		ModelName:          "test-model",
+		ModelName:          "DeepSeek-R1",
 		Port:               "3000",
 		Template:           template.Must(template.ParseFiles("static/index.html")),
 	}
@@ -23,16 +29,13 @@ func TestHealthHandler(t *testing.T) {
 	// Set up the handlers with a test configuration
 	h := setupTestHandlers()
 
-	// Create a new HTTP GET request targeting the /health endpoint
 	req, err := http.NewRequest("GET", "/health", nil)
 	if err != nil {
-		t.Fatal(err) // Fail the test if there's an issue creating the request
+		t.Fatal(err)
 	}
 
-	// Create a ResponseRecorder to record the response
 	recorder := httptest.NewRecorder()
 
-	// Wrap the healthHandler function in an http.HandlerFunc
 	handler := http.HandlerFunc(h.healthHandler)
 
 	// Serve the HTTP request
@@ -43,9 +46,7 @@ func TestHealthHandler(t *testing.T) {
 		t.Errorf("handler returned wrong status code: got %v want %v", status, http.StatusOK)
 	}
 
-	// Define the expected response body
 	expected := "Healthy."
-	// Verify that the actual response body matches the expected one
 	if recorder.Body.String() != expected {
 		t.Errorf("handler returned unexpected body: got %v want %v", recorder.Body.String(), expected)
 	}
@@ -62,16 +63,140 @@ func TestIndexHandler(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Create a ResponseRecorder to capture the HTTP response
 	recorder := httptest.NewRecorder()
-	// Wrap the indexHandler function into an http.HandlerFunc
+
 	handler := http.HandlerFunc(h.indexHandler)
 
-	// Serve the HTTP request using the handler
 	handler.ServeHTTP(recorder, req)
 
 	// Verify that the returned HTTP status code is 200 OK
 	if status := recorder.Code; status != http.StatusOK {
 		t.Errorf("handler returned wrong status code: got %v want %v", status, http.StatusOK)
+	}
+}
+
+// Create a test implementation of the makeRESTCall function
+var originalMakeRESTCall func(h *handlers, messages []Message) (string, error)
+
+// Save the original function before tests and restore after
+func init() {
+	originalMakeRESTCall = makeRESTCall
+}
+
+// Mock function for makeRESTCall that can be set during tests
+var mockRESTCallFunc func(messages []Message) (string, error)
+
+// Override the makeRESTCall function for testing
+func makeRESTCall(h *handlers, messages []Message) (string, error) {
+	if mockRESTCallFunc != nil {
+		return mockRESTCallFunc(messages)
+	}
+	return originalMakeRESTCall(h, messages)
+}
+
+// mockTokenCredential implements azcore.TokenCredential for testing purposes
+type mockTokenCredential struct {
+	token azcore.AccessToken
+	err   error
+}
+
+func (m *mockTokenCredential) GetToken(ctx context.Context, opts policy.TokenRequestOptions) (azcore.AccessToken, error) {
+	return m.token, m.err
+}
+
+// TestMakeRESTCall_Success tests the makeRESTCall function for a successful REST API call
+func TestMakeRESTCall_Success(t *testing.T) {
+	// Setup mock HTTP server
+	mockResponse := `{"choices":[{"message":{"content":"Hello, how can I help you?"}}]}`
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, mockResponse)
+	}))
+	defer server.Close()
+
+	// Setup handlers with mock config
+	h := &handlers{
+		config: &Config{
+			ModelDeploymentURL: server.URL,
+			ModelName:          "DeepSeek-R1",
+		},
+	}
+
+	// Setup mock credential
+	cred = &mockTokenCredential{
+		token: azcore.AccessToken{
+			Token:     "fake-token",
+			ExpiresOn: time.Now().Add(1 * time.Hour),
+		},
+		err: nil,
+	}
+
+	// Execute makeRESTCall
+	messages := []Message{{Role: "user", Content: "Hello"}}
+	resp, err := h.makeRESTCall(messages)
+	if err != nil {
+		t.Fatalf("makeRESTCall returned error: %v", err)
+	}
+
+	if resp != mockResponse {
+		t.Errorf("Expected response %v, got %v", mockResponse, resp)
+	}
+}
+
+// TestMakeRESTCall_InvalidURL tests the makeRESTCall function for an invalid URL
+func TestMakeRESTCall_InvalidJSONResponse(t *testing.T) {
+	// Setup mock HTTP server to return invalid JSON
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, "invalid-json")
+	}))
+	defer server.Close()
+
+	h := &handlers{
+		config: &Config{
+			ModelDeploymentURL: server.URL,
+			ModelName:          "DeepSeek-R1",
+		},
+	}
+
+	cred = &mockTokenCredential{
+		token: azcore.AccessToken{
+			Token:     "fake-token",
+			ExpiresOn: time.Now().Add(1 * time.Hour),
+		},
+		err: nil,
+	}
+
+	messages := []Message{{Role: "user", Content: "Hello"}}
+	resp, err := h.makeRESTCall(messages)
+	if err != nil {
+		t.Fatalf("Expected no error from makeRESTCall, got %v", err)
+	}
+
+	if resp != "invalid-json" {
+		t.Errorf("Expected response 'invalid-json', got %v", resp)
+	}
+}
+
+// TestMakeRESTCall_TokenError tests the makeRESTCall function for token retrieval errors
+func TestMakeRESTCall_TokenError(t *testing.T) {
+	h := &handlers{
+		config: &Config{
+			ModelDeploymentURL: "http://example.com",
+			ModelName:          "DeepSeek-R1",
+		},
+	}
+
+	cred = &mockTokenCredential{
+		token: azcore.AccessToken{},
+		err:   fmt.Errorf("token error"),
+	}
+
+	messages := []Message{{Role: "user", Content: "Hello"}}
+	_, err := h.makeRESTCall(messages)
+	if err == nil || !strings.Contains(err.Error(), "token error") {
+		t.Fatalf("Expected token error from makeRESTCall, got %v", err)
 	}
 }


### PR DESCRIPTION
This pull request includes several changes to the `src/main_test.go` file, primarily focusing on adding new dependencies, updating test configurations, and introducing new test cases for the `makeRESTCall` function.

### Dependency Additions:
* Added imports for `context`, `fmt`, `strings`, `time`, and Azure SDK packages (`azcore` and `policy`).

### Configuration Updates:
* Updated the `ModelName` in the `setupTestHandlers` function from `"test-model"` to `"DeepSeek-R1"`. (F8146a0cL12R14)

### Test Code Simplification:
* Removed redundant comments in `TestHealthHandler` and `TestIndexHandler` functions to simplify the code. [[1]](diffhunk://#diff-136599a9efc9509e9ec6715a9e4cbbfa74b7955023e7b0074f3ce4ef6f319bc8L26-L35) [[2]](diffhunk://#diff-136599a9efc9509e9ec6715a9e4cbbfa74b7955023e7b0074f3ce4ef6f319bc8L46-L48) [[3]](diffhunk://#diff-136599a9efc9509e9ec6715a9e4cbbfa74b7955023e7b0074f3ce4ef6f319bc8L65-R202)

### New Test Cases:
* Introduced a mock implementation for `makeRESTCall` and added test cases for successful REST API calls, invalid JSON responses, and token retrieval errors:
  - `TestMakeRESTCall_Success` tests a successful REST API call. (F8146a0cL66R110)
  - `TestMakeRESTCall_InvalidJSONResponse` tests handling of invalid JSON responses. (F8146a0cL112R151)
  - `TestMakeRESTCall_TokenError` tests error handling for token retrieval failures. (F8146a0cL153R176)